### PR TITLE
XIVY-16975 set row height to 32px > master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,18 +35,18 @@
         "@axonivy/ui-icons": "~13.2.0-next.720",
         "@axonivy/variable-editor": "~13.2.0-next",
         "@axonivy/variable-editor-protocol": "~13.2.0-next",
-        "@tanstack/react-query": "^5.80.6",
-        "@tanstack/react-query-devtools": "^5.80.6",
-        "i18next": "^25.2.1",
+        "@tanstack/react-query": "^5.64",
+        "@tanstack/react-query-devtools": "^5.64",
+        "i18next": "^25.0.0",
         "i18next-browser-languagedetector": "^8.0.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-i18next": "^15.4.1"
       },
       "devDependencies": {
-        "@types/react": "^19.1.6",
-        "@types/react-dom": "^19.1.6",
-        "@vitejs/plugin-react": "^4.5.1",
+        "@types/react": "^19.0.7",
+        "@types/react-dom": "^19.0.3",
+        "@vitejs/plugin-react": "^4.3.4",
         "vite": "^6.0.0"
       }
     },
@@ -15947,15 +15947,15 @@
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
-        "@types/react": "^19.1.6",
+        "@types/react": "^19.0.7",
         "@vanilla-extract/recipes": "^0.5.5",
-        "@vitejs/plugin-react": "^4.5.1",
+        "@vitejs/plugin-react": "^4.3.4",
         "i18next-parser": "^9.3.0",
         "jsdom": "^26.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "vite-plugin-dts": "^4.5.0",
-        "vitest": "^3.2.2"
+        "vitest": "^3.0.3"
       },
       "peerDependencies": {
         "@axonivy/jsonrpc": "~13.2.0-next",

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.css
@@ -21,7 +21,7 @@
   display: flex;
   position: absolute;
   width: 100%;
-  height: 36px;
+  height: 32px;
   box-sizing: border-box;
 }
 

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.test.ts
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.test.ts
@@ -52,8 +52,8 @@ test('variablesWithValidations', () => {
 });
 
 test('rowHeight', () => {
-  expect(rowHeight(undefined)).toEqual(36);
-  expect(rowHeight([])).toEqual(36);
-  expect(rowHeight([{}] as ValidationMessages)).toEqual(72);
-  expect(rowHeight([{}, {}, {}] as ValidationMessages)).toEqual(144);
+  expect(rowHeight(undefined)).toEqual(32);
+  expect(rowHeight([])).toEqual(32);
+  expect(rowHeight([{}] as ValidationMessages)).toEqual(64);
+  expect(rowHeight([{}, {}, {}] as ValidationMessages)).toEqual(128);
 });

--- a/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
+++ b/packages/variable-editor/src/components/variables/master/VariablesMasterContent.tsx
@@ -193,7 +193,7 @@ const addValidations = (variables: Array<Variable>, groupedValidations: Record<s
 };
 
 export const rowHeight = (validations?: ValidationMessages) => {
-  const height = 36;
+  const height = 32;
   if (!validations) {
     return height;
   }


### PR DESCRIPTION
This way it's easier to see the tree structure and it's the same height as in the other editors.

Before:
![before](https://github.com/user-attachments/assets/4db1070d-32cf-4b8b-b64f-3840ed596c1b)

After:
![after](https://github.com/user-attachments/assets/61549998-7f97-499d-ae01-f82efc962f24)
