### PR TITLE
Fix raise-deps with pnpm

### DIFF
--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 set -e
 
-sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" packages/*/package.json
-sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" integrations/*/package.json
-sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" package.json
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+VERSION="$1"
+
+update_version() {
+  local version="${1/SNAPSHOT/next}"
+  sed -i -E "s/(\"@axonivy[^\"]*\": \"(workspace:)?)[^\"]*(\")/\1~$version\3/" "$2"
+}
+
+for pkg in packages/*/package.json integrations/*/package.json package.json; do
+  update_version "$VERSION" "$pkg"
+done
 
 pnpm run update:axonivy:next
 if [ "$DRY_RUN" = false ]; then

--- a/.ivy/raise-version.sh
+++ b/.ivy/raise-version.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -e
 
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
 mvn --batch-mode -f integrations/standalone/pom.xml versions:set versions:commit -DnewVersion=${1}
 mvn --batch-mode -f playwright/tests/screenshots/pom.xml versions:set versions:commit -DnewVersion=${1}
 mvn --batch-mode -f playwright/variables-test-project/pom.xml versions:set versions:commit -DnewVersion=${1}
 
 pnpm install
 pnpm run raise:version ${1/SNAPSHOT/next}
-pnpm install --frozen-lockfile=false
+pnpm install --no-frozen-lockfile

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         script {
           docker.build('node-webtest', '-f build/Dockerfile.playwright .').inside {
             sh 'pnpm run update:axonivy:next'
-            sh 'pnpm install --frozen-lockfile=false && pnpm run package'
+            sh 'pnpm install --no-frozen-lockfile && pnpm run package'
             dir ('playwright/variables-test-project') {
               maven cmd: "-ntp clean verify -Dengine.page.url=${params.engineSource} -Dwebtest.cmd=webtest:${browser()}"
             }
@@ -44,7 +44,7 @@ pipeline {
             docker.build('node', '-f build/Dockerfile.node .').inside {
               def branchName = env.BRANCH_NAME.replace("/", "%252F")
               sh '''
-                pnpm install --frozen-lockfile=false
+                pnpm install --no-frozen-lockfile
                 pnpm run clean
 
                 artifacts="https://jenkins.ivyteam.io/job/core_json-schema/job/'''+branchName+'''/lastSuccessfulBuild/artifact"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "ci": "pnpm install --frozen-lockfile=false && pnpm run package && (pnpm run lint:ci || true) && pnpm run type && pnpm run test:ci && pnpm run i18n:ci",
+    "ci": "pnpm install --no-frozen-lockfile && pnpm run package && (pnpm run lint:ci || true) && pnpm run type && pnpm run test:ci && pnpm run i18n:ci",
     "clean": "pnpm run -r clean",
     "build": "tsc --build && tscp --build",
     "package": "pnpm run -r package",


### PR DESCRIPTION
raise-deps should let "workspace:" prefixes and only change the version behind.

Also replace `--frozen-lockfile=false` with `--no-frozen-lockfile`